### PR TITLE
DD-996. Remove schemaLocation attribute

### DIFF
--- a/src/datastation/scripts/fix_provenance_files.py
+++ b/src/datastation/scripts/fix_provenance_files.py
@@ -13,7 +13,6 @@ from datastation.config import init
 
 provenance_element = 'provenance ' \
                      'xmlns:prov="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/" ' \
-                     'xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/ https://easy.dans.knaw.nl/schemas/bag/metadata/prov/provenance.xsd" ' \
                      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' \
                      'xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" ' \
                      'xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" ' \


### PR DESCRIPTION
Fixes DD-996

# Description of changes
Removes the `schemaLocation` attribute from the new provenance.xml. I want to avoid Dataverse/tika trying to validate the XML. I am not sure it would with a `schemaLocation`, but why take the chance?

*

# Notify

@DANS-KNAW/dataversedans
