### PR TITLE
DD-1165: companion script for dd-verify-dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dv-dataset-replace-metadata-field-values = "datastation.scripts.replace_metadata
 dv-dataset-retrieve-metadata="datastation.scripts.retrieve_dataset_metadata:main"
 dv-dataset-retrieve-metadata-field="datastation.scripts.retrieve_dataset_metadata_field:main"
 dv-dataset-unlock = "datastation.scripts.unlock_datasets:main"
+dv-dataset-verify = "datastation.scripts.verify_dataset:main"
 dv-dataverse-oai-harvest = "datastation.scripts.oai_harvest:main"
 dv-dataverse-retrieve-pids="datastation.scripts.retrieve_dataset_pids:main"
 dv-file-prestage="datastation.scripts.prestage_files:main"

--- a/src/datastation/example-dans-datastation-tools.yml
+++ b/src/datastation/example-dans-datastation-tools.yml
@@ -1,3 +1,6 @@
+verify_dataset:
+  url: 'http://dar.dans.knaw.nl:20345'
+
 dataverse:
   api_token: your-api-token-here
   server_url: 'http://localhost:8080'

--- a/src/datastation/scripts/verify_dataset.py
+++ b/src/datastation/scripts/verify_dataset.py
@@ -1,0 +1,24 @@
+import argparse
+import requests
+import json
+
+from datastation.config import init
+
+
+def main():
+    config = init()
+    parser = argparse.ArgumentParser(description='Verify metadata of a dataset')
+    parser.add_argument(dest='doi', help='The doi of the dataset to verify, e.g. "doi:10.5072/DAR/RGICM5"')
+    args = parser.parse_args()
+
+    server_url = config['verify_dataset']['url']
+
+    response = requests.post(f'{server_url}/verify',
+                             data='{ "datasetPid": "' + args.doi + '" }',
+                             headers={'Content-Type': 'application/json'})
+    print(f"response code: {response.status_code}")
+    print(json.dumps(response.json(), indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes DD-1165: companion script for dd-verify-dataset

# Description of changes

# How to test

    poetry run dv-dataset-verify 'doi:10.5072/DAR/AJ3RZB' 2> /dev/null

with `.dans-datastation-tools.yml` containing

    verify_dataset:
      url: 'http://localhost:20345'

after launching the service

    cd dd-dataset-verify
    start.sh server etc/config.yml


# Related PRs

requires https://github.com/DANS-KNAW/dd-verify-dataset/pull/1

# Notify

@DANS-KNAW/dataversedans
