### PR TITLE
DD-1311, do not fail on first error

### DIFF
--- a/src/datastation/common/result_writer.py
+++ b/src/datastation/common/result_writer.py
@@ -28,6 +28,7 @@ class JsonResultWriter(ResultWriter):
         else:
             self.out_stream.write(", ")
         self.out_stream.write(json.dumps(result))
+        self.out_stream.flush()
 
     def close(self):
         if not self.first_result_written:


### PR DESCRIPTION
Fixes DD-1311

# Description of changes

Improved #29: 

* When processing multiple datasets the command will continue if an error occurs while processing one dataset
* The result is printed as a Json array with JsonResultWriter.


# Related PRs
#29 

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
