### PR TITLE
NO JIRA. Fixed bug in ingest-flow copy-batch

### DIFF
--- a/src/datastation/common/utils.py
+++ b/src/datastation/common/utils.py
@@ -18,6 +18,7 @@ def add_batch_proccessor_args(parser, report: bool = True):
         parser.add_argument('-r', '--report-file', default='-', help="the report file, or - for stdout",
                             dest='report_file')
 
+
 def positive_int_argument_converter(value):
     try:
         ivalue = int(value)
@@ -40,15 +41,16 @@ def print_dry_run_message(method, url, params=None, headers=None, data=None, jso
     print()
 
 
+def expand_path(path):
+    return os.path.abspath(os.path.expanduser(path))
+
+
 def is_sub_path_of(child, parent):
     """
     Returns True if child is a descendant directory of parent, or if child is a file in a descendant directory
-    of parent. Returns False otherwise. If one of the paths does not exist, returns False. The paths are first
-    converted to absolute paths."""
-    if not os.path.exists(child) or not os.path.exists(parent):
-        return False
-    absolute_parent = os.path.abspath(parent)
-    absolute_dir = os.path.abspath(child)
+    of parent. Returns False otherwise. The existence of child and parent is not checked."""
+    absolute_parent = expand_path(parent)
+    absolute_dir = expand_path(child)
     return absolute_dir.startswith(absolute_parent)
 
 

--- a/src/datastation/example-dans-datastation-tools.yml
+++ b/src/datastation/example-dans-datastation-tools.yml
@@ -19,8 +19,9 @@ migration_placeholders:
 ingest_flow:
   service_baseurl: 'http://localhost:20300'
   deposits_mode:
-    directory: '0770'
-    file: '0660'
+    # N.B. these must be integers, not strings. Use octal notation.
+    directory: 0770
+    file: 0660
   deposits_group: deposits
   ingest_areas:
     import:

--- a/src/datastation/ingestflow/ingest_flow.py
+++ b/src/datastation/ingestflow/ingest_flow.py
@@ -153,16 +153,14 @@ class IngestFlow:
         After copying, the mode of the copied files and directories will be set to the value configured in the ingest
         area."""
 
-        def get_inbox(ingest_area):
-            return expand_path(ingest_area['inbox'])
-
         abs_source = expand_path(source)
         abs_target = expand_path(target)
         if not os.path.isdir(abs_source):
             print(f"ERROR: source {source} is not a directory")
             return 1
 
-        ingest_area = next(filter(lambda ia: is_sub_path_of(abs_target, get_inbox(self.ingest_areas[ia])), self.ingest_areas), None)
+        ingest_area = next(filter(lambda ia: is_sub_path_of(abs_target, expand_path(self.ingest_areas[ia]['inbox'])),
+                                  self.ingest_areas), None)
         if ingest_area is None:
             print(
                 f"ERROR: target {target} does not seem to be in one of the inboxes of the ingest areas: {ingest_area}")

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -93,6 +93,7 @@ class TestSetPermissions:
             for f in files:
                 assert oct(os.stat(os.path.join(root, f)).st_mode)[-3:] == '666'
 
+
 class TestPositiveIntArgumentConverter(unittest.TestCase):
     def test_positive_int_argument_converter(self):
         self.assertEqual(positive_int_argument_converter("5"), 5)


### PR DESCRIPTION
NO JIRA.

# Description of changes
* Added utility function `expand_path` to make a path absolute and expand the `~` at the same time.
* Changed `is_sub_path_of` so that it no longer checks if the parent or child path exists, as that is irrelevant to the question.
* When you iterate over a dictionary with `filter`, apparently you get the keys. The code was assuming the values were returned. Fixed that.


# Notify

@DANS-KNAW/dataversedans
