### PR TITLE
Added datastation-get-component-versions command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dans-datastation-tools"
-version = "0.35.0"
+version = "0.36.0"
 description = "Command line utilities for Data Station application management"
 authors = ["DANS-KNAW"]
 packages = [

--- a/src/datastation/common/version_info.py
+++ b/src/datastation/common/version_info.py
@@ -17,14 +17,17 @@ def get_rpm_versions(prefix):
     for line in rpm_qa():
         if line.startswith(prefix):
             logging.debug(f'Found RPM matching prefix {prefix}: {line}')
-            evr = match(evr_pattern, line)
-            version = evr.group('version')
-            module = evr.group('name')
-            release = evr.group('release')
-            # Adding the release part of the EVR is not very informative for DANS modules,
-            # because it is always 1 for releases, except for SNAPSHOTs, in which case it is
-            # important to know the exact SNAPSHOT version.
-            rpm_versions[module] = f'{version}-{release}' if release != '1' else f'{version}'
+            try:
+                evr = match(evr_pattern, line)
+                version = evr.group('version')
+                module = evr.group('name')
+                release = evr.group('release')
+                # Adding the release part of the EVR is not very informative for DANS modules,
+                # because it is always 1 for releases, except for SNAPSHOTs, in which case it is
+                # important to know the exact SNAPSHOT version.
+                rpm_versions[module] = f'{version}-{release}' if release != '1' else f'{version}'
+            except:
+                rpm_versions[module] = 'ERROR'
 
     return rpm_versions
 
@@ -32,20 +35,29 @@ def get_rpm_versions(prefix):
 def get_dataverse_version(dataverse_application_path):
     with open(os.path.join(dataverse_application_path, 'WEB-INF', 'classes', 'META-INF',
                            'microprofile-config.properties'), 'r') as f:
-        for line in f:
-            if 'dataverse.version' in line:
-                return (line.split('=')[1]).strip()
+        try:
+            for line in f:
+                if 'dataverse.version' in line:
+                    return (line.split('=')[1]).strip()
+        except:
+            return 'ERROR'
 
 
 def get_dataverse_build_number(dataverse_application_path):
     with open(os.path.join(dataverse_application_path, 'WEB-INF', 'classes', 'BuildNumber.properties'), 'r') as f:
-        for line in f:
-            if 'build.number' in line:
-                return (line.split('=')[1]).strip()
+        try:
+            for line in f:
+                if 'build.number' in line:
+                    return (line.split('=')[1]).strip()
+        except:
+            return 'ERROR'
 
 
 def get_payara_version(payara_application_path):
-    with open(os.path.join(payara_application_path, 'README.txt'), 'r') as f:
-        line = next((line for line in f if match(payara_version_pattern, line)), None)
-        payara_version = match(payara_version_pattern, line).group(1)
-    return payara_version
+    try:
+        with open(os.path.join(payara_application_path, 'README.txt'), 'r') as f:
+            line = next((line for line in f if match(payara_version_pattern, line)), None)
+            payara_version = match(payara_version_pattern, line).group(1)
+        return payara_version
+    except:
+        return 'ERROR'

--- a/src/datastation/common/version_info.py
+++ b/src/datastation/common/version_info.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from re import match
 
@@ -6,7 +7,7 @@ def rpm_qa():
     return os.popen('rpm -qa')
 
 
-evr_pattern = r'(?P<name>.*?)-(?P<version>\d+\.\d+\.\d+)-(?P<release>\d+)'
+evr_pattern = r'(?P<name>.*?)-(?P<version>\d+\.\d+\.\d+)-(?P<release>[^\.]+)\.(?P<arch>.+)'
 payara_version_pattern = r'Thank you for downloading Payara Server (.*).'
 
 
@@ -15,10 +16,15 @@ def get_rpm_versions(prefix):
     rpm_versions = {}
     for line in rpm_qa():
         if line.startswith(prefix):
+            logging.debug(f'Found RPM matching prefix {prefix}: {line}')
             evr = match(evr_pattern, line)
             version = evr.group('version')
             module = evr.group('name')
-            rpm_versions[module] = version
+            release = evr.group('release')
+            # Adding the release part of the EVR is not very informative for DANS modules,
+            # because it is always 1 for releases, except for SNAPSHOTs, in which case it is
+            # important to know the exact SNAPSHOT version.
+            rpm_versions[module] = f'{version}-{release}' if release != '1' else f'{version}'
 
     return rpm_versions
 
@@ -40,8 +46,6 @@ def get_dataverse_build_number(dataverse_application_path):
 
 def get_payara_version(payara_application_path):
     with open(os.path.join(payara_application_path, 'README.txt'), 'r') as f:
-        # Find first line that matches pattern
         line = next((line for line in f if match(payara_version_pattern, line)), None)
-        # get subgroup 1 of the match
         payara_version = match(payara_version_pattern, line).group(1)
     return payara_version

--- a/src/datastation/datastation_get_component_versions.py
+++ b/src/datastation/datastation_get_component_versions.py
@@ -1,5 +1,7 @@
 import argparse
 
+import yaml
+import sys
 import rich
 from rich.console import Console
 from rich.table import Table
@@ -20,7 +22,7 @@ def get_config_version_info(config):
         }
         rich.print('WARNING: No version_info section in config file. Using default values.')
         rich.print('To get rid of this warning, add a version_info section to your config file:')
-        rich.print(default_version_info);
+        yaml.dump({'version_info': default_version_info}, sys.stdout)
         return default_version_info
 
 
@@ -38,7 +40,7 @@ def main():
     dataverse_version = get_dataverse_version(version_info['dataverse_application_path'])
     dataverse_build_number = get_dataverse_build_number(version_info['dataverse_application_path'])
     components['dataverse'] = f'{dataverse_version} build {dataverse_build_number}'
-    payara_version = get_payara_version(config['version_info']['payara_install_path'])
+    payara_version = get_payara_version(version_info['payara_install_path'])
     components['payara'] = payara_version
 
     if args.json:
@@ -48,9 +50,11 @@ def main():
         table = Table(title="Data Station Component Versions")
         table.add_column("Component")
         table.add_column("Version")
-        components.sort()
-        for component in components:
-            table.add_row(component, components[component])
+        # Get a sorted list of keys into the components dictionary
+        keys = list(components.keys())
+        keys.sort()
+        for key in keys:
+            table.add_row(key, components[key])
         console = Console()
         console.print(table)
 

--- a/src/datastation/datastation_get_component_versions.py
+++ b/src/datastation/datastation_get_component_versions.py
@@ -9,6 +9,21 @@ from datastation.common.version_info import get_rpm_versions, get_dataverse_vers
     get_payara_version
 
 
+def get_config_version_info(config):
+    if 'version_info' in config:
+        return config['version_info']
+    else:
+        default_version_info = {
+            'dans_rpm_module_prefix': 'dans.knaw.nl-',
+            'dataverse_application_path': '/var/lib/payara5/glassfish/domains/domain1/applications/dataverse/',
+            'payara_install_path': '/usr/local/payara5'
+        }
+        rich.print('WARNING: No version_info section in config file. Using default values.')
+        rich.print('To get rid of this warning, add a version_info section to your config file:')
+        rich.print(default_version_info);
+        return default_version_info
+
+
 def main():
     config = init()
 
@@ -17,9 +32,11 @@ def main():
     parser.add_argument('--json', dest='json', action='store_true', help='Output as JSON')
     args = parser.parse_args()
 
-    components = get_rpm_versions(config['version_info']['dans_rpm_module_prefix'])
-    dataverse_version = get_dataverse_version(config['version_info']['dataverse_application_path'])
-    dataverse_build_number = get_dataverse_build_number(config['version_info']['dataverse_application_path'])
+    version_info = get_config_version_info(config)
+
+    components = get_rpm_versions(version_info['dans_rpm_module_prefix'])
+    dataverse_version = get_dataverse_version(version_info['dataverse_application_path'])
+    dataverse_build_number = get_dataverse_build_number(version_info['dataverse_application_path'])
     components['dataverse'] = f'{dataverse_version} build {dataverse_build_number}'
     payara_version = get_payara_version(config['version_info']['payara_install_path'])
     components['payara'] = payara_version
@@ -31,6 +48,7 @@ def main():
         table = Table(title="Data Station Component Versions")
         table.add_column("Component")
         table.add_column("Version")
+        components.sort()
         for component in components:
             table.add_row(component, components[component])
         console = Console()

--- a/src/tests/test_version_info.py
+++ b/src/tests/test_version_info.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from datastation.common.version_info import get_rpm_versions, get_dataverse_version, get_payara_version
 
 
-def test_some_modules_with_matching_prefix_found():
+def test_get_rpm_modules_should_filter_out_packages_with_no_matching_prefix():
     with patch('datastation.common.version_info.rpm_qa') as mock_qa:
         mock_qa.return_value = ['dans.knaw.nl-dd-vault-metadata-2.2.0-1.noarch',
                                 'dans.knaw.nl-dans-schema-0.10.0-1.noarch',
@@ -18,11 +18,27 @@ def test_some_modules_with_matching_prefix_found():
         }
 
 
-def test_no_matching_modules_found():
+def test_get_rpm_modules_should_return_empty_dictionary_if_no_packages_matched_prefix():
     with patch('datastation.common.version_info.rpm_qa') as mock_qa:
         mock_qa.return_value = ['python3-rpm-generators-5-8.el8.noarch']
         versions = get_rpm_versions('dans.knaw.nl-')
         assert versions == {}
+
+
+def test_get_rpm_modules_should_accept_non_digits_in_release_part_of_evr():
+    with patch('datastation.common.version_info.rpm_qa') as mock_qa:
+        mock_qa.return_value = ['dans.knaw.nl-dd-vault-metadata-2.2.0-1.noarch',
+                                'dans.knaw.nl-dans-schema-0.10.0-SNAPSHOT20231005095642.noarch',
+                                'python3-rpm-generators-5-8.el8.noarch',
+                                'dans.knaw.nl-dd-verify-dataset-0.10.0-1.noarch',
+                                'dans.knaw.nl-dd-verify-dataset-0.10.0-1.1.noarch',
+                                ]
+        versions = get_rpm_versions('dans.knaw.nl-')
+        assert versions == {
+            'dans.knaw.nl-dd-vault-metadata': '2.2.0',
+            'dans.knaw.nl-dans-schema': '0.10.0-SNAPSHOT20231005095642',
+            'dans.knaw.nl-dd-verify-dataset': '0.10.0'
+        }
 
 
 def test_get_dataverse_version():


### PR DESCRIPTION
NO JIRA.

# Description of changes
See #49 Made the command more robust and user friendly:

* Failing to get one of the versions will now result in the value ERROR instead of crashing the command.
* If the `version_info` section is missing, you will get a warning instead of crashing the command
* The components are listed alphabetically in table mode, so it is easier to visually compare the output between servers.


# Notify

@DANS-KNAW/dataversedans
