### PR TITLE
Fixed + improved dv-dataset-destroy-migration-placeholder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dans-datastation-tools"
-version = "0.38.0"
+version = "0.39.0"
 description = "Command line utilities for Data Station application management"
 authors = ["DANS-KNAW"]
 packages = [

--- a/src/datastation/dataverse/destroy_placeholder_dataset.py
+++ b/src/datastation/dataverse/destroy_placeholder_dataset.py
@@ -12,9 +12,10 @@ def description_object_matches(description_text_pattern):
 
     return matches
 
+
 def is_migration_file(file_metadata):
     return ('directoryLabel' in file_metadata and file_metadata['directoryLabel'] == 'easy-migration') or \
-        ('directoryLabel' not in file_metadata and file_metadata['label'] != 'easy-migration.zip')
+        ('directoryLabel' not in file_metadata and file_metadata['label'] == 'easy-migration.zip')
 
 
 def destroy_placeholder_dataset(dataset_api: DatasetApi, description_text_pattern, csv_report: CsvReport,
@@ -50,7 +51,7 @@ def destroy_placeholder_dataset(dataset_api: DatasetApi, description_text_patter
 
         if len(non_easy_migration_files) > 0:
             blocker = True
-            messages.append(f"Files other than 'easy-migration' found: {len(non_easy_migration_files)}: BLOCKER")
+            messages.append(f"Files other than 'easy-migration/*' or 'easy-migration.zip' found: {len(non_easy_migration_files)}: BLOCKER")
         else:
             messages.append("Only found easy-migration files: OK")
 

--- a/src/datastation/dv_dataset_destroy_migration_placeholder.py
+++ b/src/datastation/dv_dataset_destroy_migration_placeholder.py
@@ -28,7 +28,8 @@ def main():
     batch_processor.process_pids(pids,
                                  callback=lambda pid, csv_report: destroy_placeholder_dataset(dataverse.dataset(pid),
                                                                                               description_text_pattern,
-                                                                                              csv_report))
+                                                                                              csv_report,
+                                                                                              dry_run=args.dry_run))
 
 
 if __name__ == '__main__':

--- a/src/tests/test_destroy_placeholder_dataset.py
+++ b/src/tests/test_destroy_placeholder_dataset.py
@@ -1,0 +1,22 @@
+import datastation.dataverse.destroy_placeholder_dataset
+
+
+def test_is_migration_file_returns_true_for_file_with_label_easy_migration_dot_zip():
+    file_metadata = {'label': 'easy-migration.zip'}
+    assert datastation.dataverse.destroy_placeholder_dataset.is_migration_file(file_metadata) == True
+
+
+def test_is_migration_file_returns_true_for_file_with_directory_label_easy_migration():
+    file_metadata = {'directoryLabel': 'easy-migration'}
+    assert datastation.dataverse.destroy_placeholder_dataset.is_migration_file(file_metadata) == True
+
+
+def test_is_migration_file_returns_false_for_file_with_label_not_easy_migration_dot_zip():
+    file_metadata = {'label': 'not-easy-migration.zip'}
+    assert datastation.dataverse.destroy_placeholder_dataset.is_migration_file(file_metadata) == False
+
+
+def test_is_migration_file_returns_false_for_file_with_directory_label_not_easy_migration():
+    file_metadata = {'directoryLabel': 'not-easy-migration'}
+    assert datastation.dataverse.destroy_placeholder_dataset.is_migration_file(file_metadata) == False
+


### PR DESCRIPTION
No JIRA

# Description of changes
- Implemented missing dry-run option for dv-dataset-destroy-migration-placeholder
- Refactored filtering on datasets with only 'easy-migration' files + also allowing easy-migration.zip as 'easy-migration' file (formerly, easy-migration was expected to be a directory containing up to 4 files).

# Notify

@DANS-KNAW/core-systems
