### PR TITLE
Fixing call raise_for_status_after_log(r)()

### DIFF
--- a/src/datastation/dataverse/banner_api.py
+++ b/src/datastation/dataverse/banner_api.py
@@ -20,7 +20,7 @@ class BannerApi:
             print(f"Would have sent the following request: {url}")
             return
         r = requests.get(url, headers=headers, params={'unblock-key': self.unblock_key})
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r
 
     def add(self, msg: str, dismissible_by_user: bool = False, lang: str = 'en', dry_run: bool = False):
@@ -41,7 +41,7 @@ class BannerApi:
             print(json.dumps(banner, indent=4))
             return
         r = requests.post(url, headers=headers, params={'unblock-key': self.unblock_key}, json=banner)
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r
 
     def remove(self, banner_id: int, dry_run: bool = False):
@@ -52,5 +52,5 @@ class BannerApi:
             print(f"Would have sent the following request: {url}")
             return
         r = requests.delete(url, headers=headers, params={'unblock-key': self.unblock_key})
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r

--- a/src/datastation/dataverse/dataverse_api.py
+++ b/src/datastation/dataverse/dataverse_api.py
@@ -50,7 +50,7 @@ class DataverseApi:
             return None
         else:
             r = requests.get(url, headers=headers)
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r.json()['data']['message']
 
     def add_role_assignment(self, assignee, role, dry_run=False):

--- a/src/datastation/dataverse/file_api.py
+++ b/src/datastation/dataverse/file_api.py
@@ -20,5 +20,5 @@ class FileApi:
             print_dry_run_message(method='POST', url=url, headers=headers, params=params)
             return None
         r = requests.post(url, headers=headers, params=params)
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r

--- a/src/datastation/dataverse/metrics_api.py
+++ b/src/datastation/dataverse/metrics_api.py
@@ -14,5 +14,5 @@ class MetricsApi:
             print(f"Would have sent the following request: {url}")
             return
         r = requests.get(url)
-        raise_for_status_after_log(r)()
+        raise_for_status_after_log(r)
         return r.json()['data']


### PR DESCRIPTION
Removing extra () because it does not return a function
Otherwise yo wil get errors like these:
```line 53, in get_storage_size
    raise_for_status_after_log(r)()
TypeError: 'NoneType' object is not callable
```

Fixes NO ISSUE

# Notify

@DANS-KNAW/core-systems
