### PR TITLE
Fixing typo in argument role_assignment

### DIFF
--- a/src/datastation/dv_dataset_role_assignment.py
+++ b/src/datastation/dv_dataset_role_assignment.py
@@ -105,7 +105,7 @@ def main():
 
     # Remove role assignment
     parser_remove = subparsers.add_parser('remove', help='remove role assignment from specified dataset(s)')
-    parser_remove.add_argument('role-assignment',
+    parser_remove.add_argument('role_assignment',
                                help='role assignee and alias (example: @dataverseAdmin=contributor)')
     parser_remove.add_argument('pid_or_pid_file', help='The dataset pid or the input file with the dataset pids')
     add_batch_processor_args(parser_remove)


### PR DESCRIPTION
Fixes NO ISSUE
Related to https://drivenbydata.atlassian.net/browse/DD-1600

Problem when using remove on role assigment:
```
[paulb@ar31 ~]$ dv-dataset-role-assignment remove '@PANVU=contributorplus' PAN-contributorplus.txt                                                                             
DOI,Modified,Assignee,Role,Change
2024-07-19 09:33:38 : ERROR : process_entries : Exception occurred on entry nr 1
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/datastation/common/batch_processing.py", line 84, in process_entries                                                            
    callback(obj)
  File "/usr/local/lib/python3.9/site-packages/datastation/common/batch_processing.py", line 109, in <lambda>                                                                  
    super().process_entries(entries, lambda entry: callback(entry, csv_report))
  File "/usr/local/lib/python3.9/site-packages/datastation/dv_dataset_role_assignment.py", line 62, in <lambda>                                                                
    lambda pid, csv_report: remove_role_assignment(args.role_assignment,
AttributeError: 'Namespace' object has no attribute 'role_assignment'
2024-07-19 09:33:38 : ERROR : process_entries : Stop processing because of an exception: 'Namespace' object has no attribute 'role_assignment'    

```
Inspecting `dv_dataset_role_assignment.py` showed we have:
```
parser_remove.add_argument('role-assignment',
```
should be
``` 
parser_remove.add_argument('role_assignment',
```
# Notify

@DANS-KNAW/core-systems
