### PR TITLE
DD-1624 Extra options for deposit-create-report

### DIFF
--- a/src/datastation/common/send_mail.py
+++ b/src/datastation/common/send_mail.py
@@ -9,7 +9,7 @@ class SendMail:
     #     pass
 
     @staticmethod
-    def send(to_email, subject, message_body, attachment, cc_email, bcc_email):
+    def send(to_email, subject, message_body, attachment, email_from_address, cc_email, bcc_email):
         recipients = to_email
 
         if cc_email is not None:
@@ -18,7 +18,12 @@ class SendMail:
         if bcc_email is not None:
             recipients = ' -b {0} {1} '.format(bcc_email, recipients)
 
+        email_addresses = recipients
+
+        if email_from_address is not None:
+            email_addresses = ' -r {0} {1} '.format(email_from_address, email_addresses)
+
         if attachment is not None:
-            os.system('echo "{0}" | mail -s "{1}" -a "{2}" {3}'.format(message_body, subject, attachment, recipients))
+            os.system('echo "{0}" | mail -s "{1}" -a "{2}" {3}'.format(message_body, subject, attachment, email_addresses))
         else:
-            os.system('echo "{0}" | mail -s "{1}" {2}'.format(message_body, subject, recipients))
+            os.system('echo "{0}" | mail -s "{1}" {2}'.format(message_body, subject, email_addresses))

--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -31,6 +31,7 @@ class ReportHandler:
                       "Deposits report",
                       "Please, find attached the detailed report of deposits.",
                       attachment,
+                      self.__command_line_args.email_from_address,
                       self.__command_line_args.cc_email_to,
                       self.__command_line_args.bcc_email_to)
 
@@ -46,6 +47,7 @@ def main():
     parser.add_argument('-t', '--state', help='The state of the deposit')
     parser.add_argument('-u', '--user', dest='user', help='The depositor name')
     parser.add_argument('-f', '--format', dest='file_format', default='text/csv', help='Output data format')
+    parser.add_argument('r', 'from', dest='email_from_address', help='from address')
     parser.add_argument('--email-to', dest='email_to', help='when more than one recipient: comma separated emails')
     parser.add_argument('--cc-email-to', dest='cc_email_to', help='will be sent only if email-to is defined')
     parser.add_argument('--bcc-email-to', dest='bcc_email_to', help='will be sent only if email-to is defined')


### PR DESCRIPTION
Fixes DD-1624 Extra options for deposit-create-report

# Description of changes
- Added new option to Deposit-create-report script:
   ` ('r', 'from', dest='email_from_address', help='from address')`
- Adapted send function of the class SendMail in send-mail script 

# How to test
- copy send-mail script to vagrant shared folder
- navigate to shared folder in vagrant (vagrant ssh)
- run the send function for example like this (one line command):
- `python3 -c 'from send_mail import SendMail; SendMail.send("your-dans@mail", "test -r option", "it is to test -r option", None, "your-gmail@gmail.com", None, None)'
`
- Check your emails (also junk mails)

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
