### PR TITLE
DD-1625 deposit-create-report: stuur geen report als er geen records zijn

### DIFF
--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -17,10 +17,13 @@ class ReportHandler:
             if output_file == '-':
                 print(report)
             else:
-                self.save_report_to_file(report, output_file)
+                if len(report.split('\n')) > 1:
+                    self.save_report_to_file(report, output_file)
 
-                if self.__command_line_args.email_to is not None:
-                    self.send_report_mail(output_file)
+                    if self.__command_line_args.email_to is not None:
+                        self.send_report_mail(output_file)
+                else:
+                    print("Report is empty.")
 
     def save_report_to_file(self, report, output_file):
         with open(output_file, 'w') as output:


### PR DESCRIPTION
Fixes DD-1625 deposit-create-report: stuur geen report als er geen records zijn

# Description of changes
   `deposit-creat-report` script checked for an empty report, it is when there are no selected/filtered records. If it is empty, it doesn't send emails to recipients. 

Note:
The an empty response of the server is dependent on the `Accept` header:
 - `{'Accept': 'text/csv'}`  --> ' '
 - `{'Accept': 'application/json'}` --> []

# How to test
For example run in vagrant: 
  - `/usr/local/bin/deposit-create-report --user 001 --email-to <your email>` --> should get an email
  - `/usr/local/bin/deposit-create-report --user 010 --email-to <your email>` --> should not get an email
# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
