### PR TITLE
DD-1637 Add age option to deposit-createreport script

### DIFF
--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -1,4 +1,6 @@
 import argparse
+from datetime import date, timedelta
+
 from datastation.managedeposit.manage_deposit import ManageDeposit
 from datastation.common.config import init
 from datastation.common.send_mail import SendMail
@@ -46,7 +48,11 @@ def main():
     parser.add_argument('-o', '--output-file', dest='output_file', default='-',
                         help='the file to write the output and send recipient to a to or - for stdout')
     parser.add_argument('-e', '--enddate', dest='enddate', help='Filter until the record creation of this date')
-    parser.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
+
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
+    group.add_argument('-a', '--age', dest='age', help='the number of days before today ')
+
     parser.add_argument('-t', '--state', help='The state of the deposit')
     parser.add_argument('-u', '--user', dest='user', help='The depositor name')
     parser.add_argument('-f', '--format', dest='file_format', default='text/csv', help='Output data format')
@@ -55,6 +61,9 @@ def main():
     parser.add_argument('--cc-email-to', dest='cc_email_to', help='will be sent only if email-to is defined')
     parser.add_argument('--bcc-email-to', dest='bcc_email_to', help='will be sent only if email-to is defined')
     args = parser.parse_args()
+
+    if args.age is not None and str(args.age).isnumeric(): # Note: args is a Namespace object
+        vars(args)['startdate'] = (date.today() + timedelta(days=-int(args.age))).strftime('%Y/%m/%d')
 
     server_url = config['manage_deposit']['service_baseurl'] + '/report'
 

--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -51,7 +51,7 @@ def main():
 
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
-    group.add_argument('-a', '--age', dest='age', help='the number of days before today ')
+    group.add_argument('-a', '--age', dest='age', help='Filter from record creation not older than a number of days before today ')
 
     parser.add_argument('-t', '--state', help='The state of the deposit')
     parser.add_argument('-u', '--user', dest='user', help='The depositor name')

--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -63,7 +63,7 @@ def main():
     args = parser.parse_args()
 
     if args.age is not None: # Note: args is a Namespace object
-        vars(args)['startdate'] = (date.today() + timedelta(days=-int(args.age))).strftime('%Y/%m/%d')
+        vars(args)['startdate'] = (date.today() + timedelta(days=-args.age)).strftime('%Y/%m/%d')
 
     server_url = config['manage_deposit']['service_baseurl'] + '/report'
 

--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -51,7 +51,7 @@ def main():
 
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
-    group.add_argument('-a', '--age', dest='age', help='Filter from record creation not older than a number of days before today ')
+    group.add_argument('-a', '--age', dest='age', type=int, help='Filter from record creation not older than a number of days before today ')
 
     parser.add_argument('-t', '--state', help='The state of the deposit (repeatable)', action='append')
     parser.add_argument('-u', '--user', dest='user', help='The depositor name (repeatable)', action='append')
@@ -62,7 +62,7 @@ def main():
     parser.add_argument('--bcc-email-to', dest='bcc_email_to', help='will be sent only if email-to is defined')
     args = parser.parse_args()
 
-    if args.age is not None and str(args.age).isnumeric(): # Note: args is a Namespace object
+    if args.age is not None: # Note: args is a Namespace object
         vars(args)['startdate'] = (date.today() + timedelta(days=-int(args.age))).strftime('%Y/%m/%d')
 
     server_url = config['manage_deposit']['service_baseurl'] + '/report'


### PR DESCRIPTION
Fixes DD-1637 age optie voor deposit-create-report

# Description of changes
added to `~/git/dans-core-systems/modules/dans-datastation-tools/src/datastation/deposit_create_report.py`
`add_argument('-a', '--age', dest='age', help='the number of days before today ')` 
When it is given in the command line, it will set the startdate argument to asked date, if it is an integer,

# How to test
For example, in vagrant ssh:
`python3  /vagrant/modules/dans-datastation-tools/src/datastation/deposit_create_report.py --help`
# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
