### PR TITLE
DD-1659 Convert deposit-create-report argument 'age' to a date with correct format (%Y-%m-%d)

### DIFF
--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -63,7 +63,7 @@ def main():
     args = parser.parse_args()
 
     if args.age is not None: # Note: args is a Namespace object
-        vars(args)['startdate'] = (date.today() + timedelta(days=-args.age)).strftime('%Y/%m/%d')
+        vars(args)['startdate'] = (date.today() + timedelta(days=-args.age)).strftime('%Y-%m-%d')
 
     server_url = config['manage_deposit']['service_baseurl'] + '/report'
 


### PR DESCRIPTION
Fixes DD-1659 Convert deposit-create-report argument 'age' to a date with correct format (%Y-%m-%d)

# Description of changes
deposit-create-reportscript should convert `age` argument to a date with correct format `(%Y-%m-%d)`. `(%Y/%m/%d)` is not correctly understand by the database.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
