### PR TITLE
DD-1694 Payara path correction in the example dans-datastation-tools yaml file

### DIFF
--- a/src/datastation/example-dans-datastation-tools.yml
+++ b/src/datastation/example-dans-datastation-tools.yml
@@ -43,8 +43,8 @@ manage_deposit:
 
 version_info:
   dans_rpm_module_prefix: 'dans.knaw.nl-'
-  dataverse_application_path: '/var/lib/payara5/glassfish/domains/domain1/applications/dataverse/'
-  payara_install_path: '/usr/local/payara5'
+  dataverse_application_path: '/var/lib/payara6/glassfish/domains/domain1/applications/dataverse/'
+  payara_install_path: '/usr/local/payara6'
 
 
 logging:


### PR DESCRIPTION
Fixes DD-1694 Payara path correction in the example dans-datastation-tools yaml file

# Description of changes
The scripts `get-component-version` and `get-component-version-info`  which are used to collect applications version on the product and demo servers, use payara path from `dans-datastation-tools/src/datastation/example-dans-datastation-tools.yml`. It refers to payara5 which is not correct and must be payara6. 

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
