### PR TITLE
DD-1687 Vermeld DEMO of PROD in deposit-report e-mail

### DIFF
--- a/src/datastation/deposit_create_report.py
+++ b/src/datastation/deposit_create_report.py
@@ -33,7 +33,7 @@ class ReportHandler:
 
     def send_report_mail(self, attachment):
         SendMail.send(self.__command_line_args.email_to,
-                      "Deposits report",
+                      "Deposits report ({})".format(self.__command_line_args.server),
                       "Please, find attached the detailed report of deposits.",
                       attachment,
                       self.__command_line_args.email_from_address,
@@ -56,6 +56,7 @@ def main():
     parser.add_argument('-t', '--state', help='The state of the deposit (repeatable)', action='append')
     parser.add_argument('-u', '--user', dest='user', help='The depositor name (repeatable)', action='append')
     parser.add_argument('-f', '--format', dest='file_format', default='text/csv', help='Output data format')
+    parser.add_argument('-v', '--server', dest='server', default='TEST', help='which host (PROD/DEMO)')
     parser.add_argument('-r', '--from', dest='email_from_address', help='from address')
     parser.add_argument('--email-to', dest='email_to', help='when more than one recipient: comma separated emails')
     parser.add_argument('--cc-email-to', dest='cc_email_to', help='will be sent only if email-to is defined')


### PR DESCRIPTION
Fixes DD-1678 Vermeld DEMO of PROD in deposit-report e-mail (Python part)

# Description of changes
Created a new option to define the server group (PROD/DEMO) and it will be give through to email application as part of the report email subject.
 `parser.add_argument('-v', '--server', dest='server', default='TEST', help='which host (PROD/DEMO)')`

# How to test
It also needs Ansible changes. 

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
