### PR TITLE
DD-1763 Voeg --age parameter toe aan deposit-clean-data

### DIFF
--- a/src/datastation/deposit_clean_data.py
+++ b/src/datastation/deposit_clean_data.py
@@ -1,23 +1,56 @@
 import argparse
+import csv
 from datetime import date, timedelta
+import io
+import os
+import  shutil
 
 from datastation.managedeposit.manage_deposit import ManageDeposit
 from datastation.common.config import init
 
 
-def clean_manage_deposit_data(server_url, args):
-    result = ManageDeposit(args).clean_data(server_url)
-    if result is not None:
-        print(result)
+class CleanHandler:
+    def __init__(self, server_url, cmd_args):
+        self.__deposit_folder_index_in_csv = 1
+        self.__deposit_location_index_in_csv = 7
+        self.__server_url = server_url
+        self.__command_line_args = cmd_args
+
+    def handle_request(self):
+        report = ManageDeposit(self.__command_line_args).create_report(self.__server_url)
+
+        if report is not None and len(report.split('\n')) > 1:
+            self.remove_folders(self.collect_paths(report))
+        else:
+            print("deposit_clean_data: report is empty.")
+
+    def collect_paths(self, csv_data):
+        paths = []
+        csv_mem = io.StringIO(csv_data)
+        csv_reader = csv.reader(csv_mem)
+        for row in csv_reader:
+            if len(row) > max(self.__deposit_folder_index_in_csv, self.__deposit_location_index_in_csv):
+                paths.append(row[self.__deposit_location_index_in_csv] + "/" + row[self.__deposit_folder_index_in_csv])
+
+        return paths
+
+    def remove_folders(self, paths):
+        for path in paths:
+            if os.path.exists(path) and os.path.isdir(path):
+                shutil.rmtree(path)
+                print(f"Folder '{path}' has been removed successfully.")
+            else:
+                print(f"Folder '{path}' does not exist.")
 
 
 def main():
     config = init()
     parser = argparse.ArgumentParser(prog='deposit_data_cleaner', description='Clean up dd-manage-deposit database')
+    parser.add_argument('-f', '--format', dest='file_format', default='text/csv', help='Output data format')
     parser.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
 
     group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('-a', '--age', dest='age', type=int, help='Filter from record creation older than a number of days before today')
+    group.add_argument('-a', '--age', dest='age', type=int, help='Filter records older than a number of days before today')
     group.add_argument('-e', '--enddate', dest='enddate', help='Filter until the record creation of this date')
 
     parser.add_argument('-t', '--state', dest='state', help='The state of the deposit (repeatable)', action='append')
@@ -27,9 +60,9 @@ def main():
     if args.age is not None: # Note: args is a Namespace object
         vars(args)['enddate'] = (date.today() + timedelta(days=-args.age)).strftime('%Y-%m-%d')
 
-    server_url = config['manage_deposit']['service_baseurl'] + '/delete-deposit'
+    server_url = config['manage_deposit']['service_baseurl'] + '/report'
 
-    clean_manage_deposit_data(server_url, args)
+    CleanHandler(server_url, args).handle_request()
 
 
 if __name__ == '__main__':

--- a/src/datastation/deposit_clean_data.py
+++ b/src/datastation/deposit_clean_data.py
@@ -1,4 +1,6 @@
 import argparse
+from datetime import date, timedelta
+
 from datastation.managedeposit.manage_deposit import ManageDeposit
 from datastation.common.config import init
 
@@ -12,11 +14,18 @@ def clean_manage_deposit_data(server_url, args):
 def main():
     config = init()
     parser = argparse.ArgumentParser(prog='deposit_data_cleaner', description='Clean up dd-manage-deposit database')
-    parser.add_argument('-e', '--enddate', dest='enddate', help='Filter until the record creation of this date')
     parser.add_argument('-s', '--startdate', dest='startdate', help='Filter from the record creation of this date')
-    parser.add_argument('-t', '--state', dest='state', help='The state of the deposit')
-    parser.add_argument('-u', '--user', dest='user', help='The depositor name')
+
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('-a', '--age', dest='age', type=int, help='Filter from record creation older than a number of days before today')
+    group.add_argument('-e', '--enddate', dest='enddate', help='Filter until the record creation of this date')
+
+    parser.add_argument('-t', '--state', dest='state', help='The state of the deposit (repeatable)', action='append')
+    parser.add_argument('-u', '--user', dest='user', help='The depositor name (repeatable)', action='append')
     args = parser.parse_args()
+
+    if args.age is not None: # Note: args is a Namespace object
+        vars(args)['enddate'] = (date.today() + timedelta(days=-args.age)).strftime('%Y-%m-%d')
 
     server_url = config['manage_deposit']['service_baseurl'] + '/delete-deposit'
 


### PR DESCRIPTION
Fixes DD-1763 Voeg --age parameter toe aan deposit-clean-data

# Description of changes
- added `--age` parameter to give an int parameter which will be used in 'today - age' as an 'end-date'.
  - end-date will be used to clean de dd-dataverse-ingest work-folder (`/tmp` subfolders)  until the given end-date
- `mutually_exclusive` parameters:
  - `--enddate` 
  - `--age`
# How to test
Ran the script in a prepared test environment in vagrant  with the age parameter `--age 612`
  - tested on 4 March 2025 and the creation day of those deposit was 2023-06-30
  - **Note**  also that the `delete` column is changed automatically and set to `false` in `dd-manage-deposit` internal database.

```
depositor | depositId | bagName | depositState | depositCreationTimestamp | depositUpdateTimestamp | description | location | storageInBytes | deleted
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
jangoogle | d3559071-474d-4825-b0a1-f1d2b07142a3 | all-mappings | PUBLISHED | 2023-06-30T17:35:18.934453+02:00 | 2025-03-03T14:55:03.328627+01:00 | The deposit was successfully ingested in the Data Station and will be automatically archived | /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/processed | 17723 | true
user001 | b9e2bf38-ec9f-4c29-9b75-ae725c8fcea5 | default-open | PUBLISHED | 2024-12-01T11:31:13.819851+01:00 | 2024-12-01T11:32:15.764606+01:00 | The deposit was successfully ingested in the Data Station and will be automatically archived. | /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/processed | 1749155 | false
jangoogle | 1c242a44-7c40-42e4-8215-8a0a19e1474f | all-mappings | FAILED | 2023-06-30T17:30:04.055385+02:00 | 2025-03-03T14:47:48.903738+01:00 | Failed /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox/1c242a44-7c40-42e4-8215-8a0a19e1474f: Error creating dataset, deleting draft | /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/failed | 17660 | true
user001 | 2bacaf7e-7d5c-47e4-96af-60df763eee84 | audiences | PUBLISHED | 2024-12-01T11:36:05.091256+01:00 | 2024-12-01T11:36:10.882592+01:00 | The deposit was successfully ingested in the Data Station and will be automatically archived. | /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/processed | 3216665 | false
jangoogle | 4ec7b614-f3b1-4c18-8ff7-bab5843f3505 | all-mappings | FAILED | 2023-06-30T17:27:01.781809+02:00 | 2025-03-03T14:48:11.495391+01:00 | Failed /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox/4ec7b614-f3b1-4c18-8ff7-bab5843f3505: Error creating dataset, deleting draft | /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/failed | 17660 | true
```
  



# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
